### PR TITLE
changing DI reference to 2.1

### DIFF
--- a/src/Extensions/Extensions.csproj
+++ b/src/Extensions/Extensions.csproj
@@ -25,6 +25,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.18" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
There's a doc question here: https://github.com/MicrosoftDocs/azure-docs/issues/61050 about why we require a ref to Extensions.DependencyInjection 2.2.0 when everything else we create is 2.1. It means you're not able to add a reference to `Microsoft.AspNetCore.App` 2.1 as it doesn't allow anything >= 2.2. 

Not sure if there was an explicit reason for 2.2 here or if we can safely roll it back and relax the restriction.