### PR TITLE
Onboard dependency restores to CFS

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
-    <add key="AzureFunctionsTempStaging" value="https://azfunc.pkgs.visualstudio.com/e6a70c92-4128-439f-8012-382fe78d6396/_packaging/AzureFunctionsTempStaging/nuget/v3/index.json" />
+    <add key="upstream-public" value="https://pkgs.dev.azure.com/azfunc/public/_packaging/upstream-public/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/eng/ci/templates/jobs/build-artifacts.yml
+++ b/eng/ci/templates/jobs/build-artifacts.yml
@@ -23,7 +23,10 @@ jobs:
   steps:
   - pwsh: dotnet --version
     displayName: "Echo dotnet version"
-  
+
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet feeds'
+
   - task: DotNetCoreCLI@2
     displayName: 'Build project'
     inputs:


### PR DESCRIPTION
## Summary
- route all repository NuGet restores through the `azfunc/public/upstream-public` CFS feed
- remove direct `nuget.org` and obsolete staging-feed access from the root `NuGet.config`
- authenticate Azure Pipelines before the shared build job performs its implicit restore
- audit all tracked CI, scripts, package-manager configuration, and nested projects; no npm or Python dependency-install paths are present

## Validation
- `dotnet restore Extensions.sln --configfile NuGet.config --no-cache --force-evaluate`
- `dotnet test Extensions.sln --no-restore -c Release`
- confirmed `dotnet nuget list source --configfile NuGet.config` reports only `upstream-public`
- confirmed no direct NuGet, npm, or PyPI public-feed references remain in repository-owned build/development paths